### PR TITLE
chore: bump ovt to latest beta

### DIFF
--- a/trivalent-chromium-clean-source.spec
+++ b/trivalent-chromium-clean-source.spec
@@ -21,7 +21,7 @@ Name:	 trivalent-chromium-clean-source
   -- This IS NOT the version of the browser
   -- It is only used if it is greater than the automated version detection
   -- The point is to update to an arbitrary greater release tag, like early stable or beta tags
-  local off_version_tag = "148.0.7778.96"
+  local off_version_tag = "149.0.7827.53"
   -- This was added because Google shipped an update but forgot to ship a security fix:
   --   https://github.com/uazo/cromite/issues/2427
   -- And didn't ship said update in stable.


### PR DESCRIPTION
https://chromereleases.googleblog.com/2026/05/chrome-beta-for-desktop-update_02063643260.html